### PR TITLE
Fixed error if logging module does not exist.

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -25,8 +25,11 @@ except ImportError:
             print('WARNING: ' + entry)
         def info(self, entry):
             print('INFO: ' + entry)
-        def debug(self, entry):
-            print('DEBUG: ' + entry)
+        def debug(self, entry, value=None):
+            if value:
+                print('DEBUG: ' + entry % value)
+            else:
+                print('DEBUG: ' + entry)
     log = logging()
 
 class ScheduleError(Exception):


### PR DESCRIPTION
Fixed error if logging module does not exist.

Without this fix, the following error would occur.
>   File "/lib/schedule/__init__.py", line 588, in run
> TypeError: function takes 2 positional arguments but 3 were given